### PR TITLE
Subscription Logic v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "imgflip": "^2.0.0",
         "inspirational-quotes": "^1.0.8",
         "m3u8stream": "^0.7.1",
+        "morse": "^0.1.0",
         "node-fetch": "^2.6.0",
         "nodemailer": "^6.4.11",
         "novelcovid": "^3.0.0",

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -487,8 +487,7 @@ export default class Bot extends Discord.Client {
     }
 
     fetchJSONFromURL(url: string, announce?: boolean, log?: boolean): any {
-        console.group()
-        console.log(`Fetching JSON from ${url}...`)
+        console.group(`Fetching JSON from ${url}...`)
         if (announce) this.textChannel.send(`Fetching from ${url}...`)
 
         // Asyncrhonous fetching

--- a/src/bot_functions/DataHandler.ts
+++ b/src/bot_functions/DataHandler.ts
@@ -60,7 +60,7 @@ export default class BotData {
 				}
 				return null
 			} else if (err.message.includes('Unexpected end')) {
-				console.error('The Subscription collection JSON is malformed. Please fix.')
+				console.error('The user data collection JSON is malformed. Please fix.')
 			}
 		}
 		if (log) console.log(data)

--- a/src/bot_functions/DataHandler.ts
+++ b/src/bot_functions/DataHandler.ts
@@ -162,8 +162,8 @@ export default class BotData {
 		var data = this.getUserDataFile()
 
 		//  Find user...
-		let userData: Data.UserSave = data.find((matchedUser: any) => {
-			return matchedUser._id == id
+		let userData: Data.UserSave = data.find((user: any) => {
+			return user._id == id
 		})
 
 		if (userData === undefined || force) {
@@ -339,5 +339,8 @@ export default class BotData {
 
 		//Time Data
 		await this.updateS3Object(FileSystem.readFileSync(BotTimeKeeper.TIME_DATA_FILE), BotTimeKeeper.S3_SAVE_NAME)
+
+		//Subscription Data
+		await this.updateS3Object(FileSystem.readFileSync(BotSubscriptionHandler.SUBSCRIPTION_DATA_FILE), BotSubscriptionHandler.S3_SAVE_NAME)
 	}
 }

--- a/src/bot_functions/DataHandler.ts
+++ b/src/bot_functions/DataHandler.ts
@@ -19,6 +19,7 @@ import AUTH from '../user_creds.json'
 
 import aws from 'aws-sdk'
 import BotTimeKeeper from './_state/TimeKeeper'
+import BotSubscriptionHandler from './_state/SubscriptionHandler'
 
 /*  Locations  */
 const SAVE_DATA = __dirname + '/../../save_data'
@@ -324,6 +325,9 @@ export default class BotData {
 		if (!timeFile) await this.updateS3Object(FileSystem.readFileSync(BotTimeKeeper.TIME_DATA_FILE), BotTimeKeeper.S3_SAVE_NAME)
 		FileSystem.writeFileSync((BotTimeKeeper.TIME_DATA_FILE), timeFile.Body.toString())
 
+		let subscriptionFile: aws.S3.GetObjectOutput = await this.getS3Object(BotSubscriptionHandler.S3_SAVE_NAME)
+		if (!subscriptionFile) await this.updateS3Object(FileSystem.readFileSync(BotSubscriptionHandler.SUBSCRIPTION_DATA_FILE), BotSubscriptionHandler.S3_SAVE_NAME)
+		FileSystem.writeFileSync((BotSubscriptionHandler.SUBSCRIPTION_DATA_FILE), subscriptionFile.Body.toString())
 	}
 	/**
 	 * Updates the S3 bucket with the following objects.

--- a/src/bot_functions/DataHandler.ts
+++ b/src/bot_functions/DataHandler.ts
@@ -59,8 +59,9 @@ export default class BotData {
 						console.error(err)
 				}
 				return null
+			} else if (err.message.includes('Unexpected end')) {
+				console.error('The Subscription collection JSON is malformed. Please fix.')
 			}
-
 		}
 		if (log) console.log(data)
 
@@ -325,6 +326,7 @@ export default class BotData {
 		if (!timeFile) await this.updateS3Object(FileSystem.readFileSync(BotTimeKeeper.TIME_DATA_FILE), BotTimeKeeper.S3_SAVE_NAME)
 		FileSystem.writeFileSync((BotTimeKeeper.TIME_DATA_FILE), timeFile.Body.toString())
 
+		// Subscription Data
 		let subscriptionFile: aws.S3.GetObjectOutput = await this.getS3Object(BotSubscriptionHandler.S3_SAVE_NAME)
 		if (!subscriptionFile) await this.updateS3Object(FileSystem.readFileSync(BotSubscriptionHandler.SUBSCRIPTION_DATA_FILE), BotSubscriptionHandler.S3_SAVE_NAME)
 		FileSystem.writeFileSync((BotSubscriptionHandler.SUBSCRIPTION_DATA_FILE), subscriptionFile.Body.toString())

--- a/src/bot_functions/TriggerHandlers.ts
+++ b/src/bot_functions/TriggerHandlers.ts
@@ -392,21 +392,21 @@ export default class TriggerHandlers {
     private static checkForSubscriptionCreateRequest(message = TriggerHandlers.message) {
         for (const trigger of TRIGGERS.subscription.create_general)
             if (message.toString().toLowerCase().startsWith(trigger))
-                return BotSubscriptionCommands.createSubscription(message)
+                return BotSubscriptionCommands.createSubscription(message as Discord.Message, trigger)
         //  Unset Restricted Role
     }
 
     private static checkForSubscriptionDeleteRequest(message = TriggerHandlers.message) {
         for (const trigger of TRIGGERS.subscription.delete_general)
             if (message.toString().toLowerCase().startsWith(trigger))
-                return BotSubscriptionCommands.deleteSubscription(message)
+                return BotSubscriptionCommands.deleteSubscription(message as Discord.Message, trigger)
         //  Unset Restricted Role
     }
 
     private static checkForSubscriptionListRequest(message = TriggerHandlers.message) {
         for (const trigger of TRIGGERS.subscription.list_general)
             if (message.toString().toLowerCase().startsWith(trigger))
-                return BotSubscriptionCommands.listSubscriptionsInChannel(message)
+                return BotSubscriptionCommands.listSubscriptionsForChannel(message as Discord.Message, trigger)
         //  Unset Restricted Role
     }
 

--- a/src/bot_functions/TriggerHandlers.ts
+++ b/src/bot_functions/TriggerHandlers.ts
@@ -30,6 +30,7 @@ import BotModuleFun from './general/FunFunctions'
 import BotWordplay from './wordplay/WordplayFunctions'
 import BotModuleWarcraft from './fetching/game/blizzard/WarcraftDataFunctions'
 import BotModuleGiphy from './fetching/gif/GiphyFunctions'
+import BotSubscriptionCommands from './general/SubscriptionCommands'
 
 
 export default class TriggerHandlers {
@@ -80,6 +81,10 @@ export default class TriggerHandlers {
         TriggerHandlers.checkForNameChangeRequest,
         TriggerHandlers.checkForRestrictedRoleAssignRequest,
         TriggerHandlers.checkForRestrictedRoleUnassignRequest,
+
+        TriggerHandlers.checkForSubscriptionCreateRequest,
+        TriggerHandlers.checkForSubscriptionDeleteRequest,
+        TriggerHandlers.checkForSubscriptionListRequest,
 
         // Minigame Requests
         TriggerHandlers.checkForDiceRollRequest,
@@ -381,6 +386,27 @@ export default class TriggerHandlers {
         for (const trigger of TRIGGERS.server_mod_triggers.unset_restricted_role)
             if (message.toString().toLowerCase().startsWith(trigger))
                 return BotModuleRestrictedRole.unassignFromRestrictedRole(trigger)
+        //  Unset Restricted Role
+    }
+
+    private static checkForSubscriptionCreateRequest(message = TriggerHandlers.message) {
+        for (const trigger of TRIGGERS.subscription.create_general)
+            if (message.toString().toLowerCase().startsWith(trigger))
+                return BotSubscriptionCommands.createSubscription(message)
+        //  Unset Restricted Role
+    }
+
+    private static checkForSubscriptionDeleteRequest(message = TriggerHandlers.message) {
+        for (const trigger of TRIGGERS.subscription.delete_general)
+            if (message.toString().toLowerCase().startsWith(trigger))
+                return BotSubscriptionCommands.deleteSubscription(message)
+        //  Unset Restricted Role
+    }
+
+    private static checkForSubscriptionListRequest(message = TriggerHandlers.message) {
+        for (const trigger of TRIGGERS.subscription.list_general)
+            if (message.toString().toLowerCase().startsWith(trigger))
+                return BotSubscriptionCommands.listSubscriptionsInChannel(message)
         //  Unset Restricted Role
     }
 

--- a/src/bot_functions/TriggerHandlers.ts
+++ b/src/bot_functions/TriggerHandlers.ts
@@ -287,12 +287,12 @@ export default class TriggerHandlers {
         for (const baseTrigger of TRIGGERS.reddit_fetch.default)
             for (const trigger of TRIGGERS.reddit_fetch.query_type.post)
                 if (message.toString().toLowerCase().startsWith(`${baseTrigger} ${trigger}`))
-                    return BotModuleReddit.fireRedditSubmissionMessage(`${baseTrigger} ${trigger}`)
+                    return BotModuleReddit.fireRedditSubmissionMessage(null, `${baseTrigger} ${trigger}`)
         //  Get copypasta post [from Reddit]
 
         for (const trigger of TRIGGERS.reddit_fetch.copypasta.default)
             if (message.toString().toLowerCase().startsWith(trigger))
-                return BotModuleReddit.fireCopypastaFetch(trigger)
+                return BotModuleReddit.fireCopypastaFetch(null, trigger)
         //  Get copypasta post [from Reddit]
     }
 

--- a/src/bot_functions/TriggerHandlers.ts
+++ b/src/bot_functions/TriggerHandlers.ts
@@ -83,6 +83,7 @@ export default class TriggerHandlers {
         TriggerHandlers.checkForRestrictedRoleUnassignRequest,
 
         TriggerHandlers.checkForSubscriptionCreateRequest,
+        TriggerHandlers.checkForSubscriptionEditRequest,
         TriggerHandlers.checkForSubscriptionDeleteRequest,
         TriggerHandlers.checkForSubscriptionListRequest,
 
@@ -393,6 +394,13 @@ export default class TriggerHandlers {
         for (const trigger of TRIGGERS.subscription.create_general)
             if (message.toString().toLowerCase().startsWith(trigger))
                 return BotSubscriptionCommands.createSubscription(message as Discord.Message, trigger)
+        //  Unset Restricted Role
+    }
+
+    private static checkForSubscriptionEditRequest(message = TriggerHandlers.message) {
+        for (const trigger of TRIGGERS.subscription.update_general)
+            if (message.toString().toLowerCase().startsWith(trigger))
+                return BotSubscriptionCommands.updateSubscription(message as Discord.Message, trigger)
         //  Unset Restricted Role
     }
 

--- a/src/bot_functions/TriggerHandlers.ts
+++ b/src/bot_functions/TriggerHandlers.ts
@@ -84,6 +84,7 @@ export default class TriggerHandlers {
         // Minigame Requests
         TriggerHandlers.checkForDiceRollRequest,
         TriggerHandlers.checkFor8BallRequest,
+        TriggerHandlers.checkForPingPongRequest,
 
         // Bot Sudo Requests
         TriggerHandlers.checkForBotKillRequest,
@@ -399,6 +400,13 @@ export default class TriggerHandlers {
         for (const trigger of TRIGGERS.magic_ball)
             if (message.toString().toLowerCase().startsWith(trigger))
                 return BotModuleFun.eightBall(null, trigger)
+        //  Get anime recommendation [from My Anime List (JikanTS)]
+    }
+
+    private static checkForPingPongRequest(message = TriggerHandlers.message) {
+        for (const trigger of TRIGGERS.ping_pong.default)
+            if (message.toString().toLowerCase().startsWith(trigger))
+                return BotGeneralCommands.firePingPongMessage(message.channel as Discord.TextChannel, trigger)
         //  Get anime recommendation [from My Anime List (JikanTS)]
     }
 

--- a/src/bot_functions/TriggerHandlers.ts
+++ b/src/bot_functions/TriggerHandlers.ts
@@ -85,6 +85,7 @@ export default class TriggerHandlers {
         TriggerHandlers.checkForSubscriptionCreateRequest,
         TriggerHandlers.checkForSubscriptionEditRequest,
         TriggerHandlers.checkForSubscriptionDeleteRequest,
+        TriggerHandlers.checkForSubscriptionGetRequest,
         TriggerHandlers.checkForSubscriptionListRequest,
 
         // Minigame Requests
@@ -394,28 +395,30 @@ export default class TriggerHandlers {
         for (const trigger of TRIGGERS.subscription.create_general)
             if (message.toString().toLowerCase().startsWith(trigger))
                 return BotSubscriptionCommands.createSubscription(message as Discord.Message, trigger)
-        //  Unset Restricted Role
     }
 
     private static checkForSubscriptionEditRequest(message = TriggerHandlers.message) {
         for (const trigger of TRIGGERS.subscription.update_general)
             if (message.toString().toLowerCase().startsWith(trigger))
                 return BotSubscriptionCommands.updateSubscription(message as Discord.Message, trigger)
-        //  Unset Restricted Role
     }
 
     private static checkForSubscriptionDeleteRequest(message = TriggerHandlers.message) {
         for (const trigger of TRIGGERS.subscription.delete_general)
             if (message.toString().toLowerCase().startsWith(trigger))
                 return BotSubscriptionCommands.deleteSubscription(message as Discord.Message, trigger)
-        //  Unset Restricted Role
+    }
+
+    private static checkForSubscriptionGetRequest(message = TriggerHandlers.message) {
+        for (const trigger of TRIGGERS.subscription.get_general)
+            if (message.toString().toLowerCase().startsWith(trigger))
+                return BotSubscriptionCommands.getSubscription(message as Discord.Message, trigger)
     }
 
     private static checkForSubscriptionListRequest(message = TriggerHandlers.message) {
         for (const trigger of TRIGGERS.subscription.list_general)
             if (message.toString().toLowerCase().startsWith(trigger))
                 return BotSubscriptionCommands.listSubscriptionsForChannel(message as Discord.Message, trigger)
-        //  Unset Restricted Role
     }
 
     /*  ----    Fun Functions   ---- */

--- a/src/bot_functions/_state/SubscriptionHandler.ts
+++ b/src/bot_functions/_state/SubscriptionHandler.ts
@@ -19,6 +19,7 @@ import { Subscriptions } from './../../types/index';
 import BotGeneralCommands from './../general/GeneralCommands'
 
 import SUBREFS from '../../bot_knowledge/references/subscriptions.json'
+import BotModuleReddit from '../fetching/reddit/RedditFunctions';
 
 let dataSkeleton: Data.SubscriptionSave =
 {
@@ -275,8 +276,12 @@ export default class BotSubscriptionHandler {
             case 'REDDITPOST':
                 //TODO
                 break;
+            case 'COPYPASTATIME':
+                BotModuleReddit.fireCopypastaFetch(channel)
+                break;
             case 'SHITPOSTTIME':
-                //! TODO hell yeah
+                //! TODO Reroute the message to the function instead of just Context
+                BotModuleReddit.fireRedditSubmissionMessage('r/shitpostingdfsadfasd', 'best', channel)
                 break;
             default:
                 break;

--- a/src/bot_functions/_state/SubscriptionHandler.ts
+++ b/src/bot_functions/_state/SubscriptionHandler.ts
@@ -24,7 +24,7 @@ let dataSkeleton: Data.SubscriptionSave =
     _enabled: false,
     name: 'butt',
     frequencyMilli: 0,
-    featureCode: 'Nothing',
+    featureCode: 'NOTHING',
     sampleData: { sampleArg: 'Yuh' }
 }
 
@@ -244,16 +244,16 @@ export default class BotSubscriptionHandler {
         // Make sure your function can handle sending to a channel id.
         let channel: Discord.TextChannel = bot.channels.cache.get(subscribedChannelId) as Discord.TextChannel
         switch (subscription.featureCode) {
-            case 'Ping':
+            case 'PING':
                 BotGeneralCommands.firePingPongMessage(channel)
                 break;
-            case 'DayCounter':
+            case 'DAYCOUNTER':
                 //TODO
                 break;
-            case 'QuoteFetch':
+            case 'QUOTEFETCH':
                 //TODO
                 break;
-            case 'RedditPost':
+            case 'REDDITPOST':
                 //TODO
                 break;
             default:

--- a/src/bot_functions/_state/SubscriptionHandler.ts
+++ b/src/bot_functions/_state/SubscriptionHandler.ts
@@ -276,7 +276,7 @@ export default class BotSubscriptionHandler {
                 //TODO
                 break;
             case 'SHITPOSTTIME':
-                //TODO
+                //! TODO hell yeah
                 break;
             default:
                 break;

--- a/src/bot_functions/_state/SubscriptionHandler.ts
+++ b/src/bot_functions/_state/SubscriptionHandler.ts
@@ -1,11 +1,134 @@
+/**
+ * Handles processing any subscriptions created by a user in the context of
+ * a direct message channel or guild channel. 
+ * 
+ * There is a single file that collects and stores all the needed subscription info
+ * in the form of a JSON.
+ *
+ * @author: Joe V.
+ * @date August 2020
+ */
+
 import Bot from '../../Bot';
 import Discord from 'discord.js'
+
+import * as FileSystem from 'fs'
+import { Data } from './../../types/data_types/Data'
 
 import { Subscriptions } from './../../types/index';
 import BotGeneralCommands from './../general/GeneralCommands'
 
-export default class SubscriptionHandler {
-    static RunTask(subscription: Subscriptions.Subscription) {
+export default class BotSubscriptionHandler {
+    static SAVE_DATA = __dirname + '/../../../save_data'
+    static SUBSCRIPTION_DATA_FILE = `${BotSubscriptionHandler.SAVE_DATA}/megadorkbot_subscription_collection.json`
+    static S3_SAVE_NAME = 'save_data/megadorkbot_subscription_collection.json'
+
+    static getSubscriptionData() {
+        try {
+            var data: Data.SubscriptionSave =
+                JSON.parse(FileSystem.readFileSync(this.SUBSCRIPTION_DATA_FILE).toString())
+        } catch (err) {
+            let bot: Bot = globalThis.bot
+            if (err.code === 'ENOENT') {
+                console.info('Subscription data file is missing! Creating new collection...')
+                try {
+                    return this.instantiateSubscriptionData(true, true)
+                } catch (err) {
+                    bot.saveBugReport(err, this.getSubscriptionData.name, true)
+                }
+                return null
+            } else bot.saveBugReport(err)
+        }
+        return data
+    }
+
+    /**
+	 * Creates a new datastore file for the server's instance.
+	 * 
+	 * @param  {boolean} fetch? Returns the new data file.
+	 * @param  {boolean} force? Erases the existing datastore if it already exists.
+	 */
+    static instantiateSubscriptionData(fetch?: boolean, force?: boolean) {
+        if (!force &&
+            JSON.parse(FileSystem.readFileSync(this.SUBSCRIPTION_DATA_FILE).toString())) {
+            console.log('Data already exists.')
+            return null
+        }
+
+        let dataSkeleton: Data.SubscriptionSave =
+        {
+            _type: 'test',
+            frequencyMilli: 0,
+            featureCode: 'Nothing',
+            sampleData: { sampleArg: 'Yuh' }
+        }
+
+        try {
+            FileSystem.writeFileSync(this.SUBSCRIPTION_DATA_FILE, JSON.stringify(dataSkeleton))
+
+            if (fetch) return this.getSubscriptionData()
+            console.log(`New Subscription Data save file created.\n`)
+        } catch (err) {
+            //  If folder is missing
+            if (err.code === 'ENOENT') {
+                FileSystem.mkdirSync(BotSubscriptionHandler.SAVE_DATA, { recursive: true })
+            } else {
+                let bot: Bot = globalThis.bot
+
+                console.error('Error creating new timekeeping file.')
+                bot.saveBugReport(err)
+            }
+        }
+    }
+
+    /**
+	 * Updates an existing user's data with given new data.
+	 * 
+	 * @param  {number|string} id User's Discord ID
+	 * @param  {object} newData New data to overwrite existing data with.
+	 */
+    static updateSubscriptionData(newData: Data.SubscriptionSave, log?: boolean) {
+        var data = this.getSubscriptionData()
+
+        if (log) {
+            console.log(`Updating time data...`)
+            console.group()
+
+            console.log(`Old Data:`)
+            console.info(data)
+            console.log(`New Data:`)
+            console.info(newData)
+        }
+
+        this.writeSubscriptionDataFile(newData)
+
+        if (log) {
+            console.log(`\Subscription data updated. 📰🌩`)
+            console.groupEnd()
+        }
+    }
+
+	/**
+	 * Overwrites the current datastore file with any given data.
+	 * 
+	 * @param  {any} data
+	 */
+    private static writeSubscriptionDataFile(data: any) {
+        if (typeof data === 'object')
+            try {
+                FileSystem.writeFileSync(this.SUBSCRIPTION_DATA_FILE, JSON.stringify(data))
+            } catch (err) {
+                let bot: Bot = globalThis.bot
+
+                bot.saveBugReport(err, this.writeSubscriptionDataFile.name, true)
+                if (err.code === 'ENOENT') {
+                    console.error(`Subscription Data has been deleted. Please restart the Bot to load new data.`)
+                    process.exit(404)
+                } else throw err
+            }
+    }
+
+    static runTask(subscription: Subscriptions.Subscription) {
         let bot: Bot = globalThis.Bot
 
         let subscribedChannelId: string
@@ -17,6 +140,8 @@ export default class SubscriptionHandler {
         else if (subscription instanceof Subscriptions.UserSubscription)
             subscribedChannelId = subscription.userId
 
+        // List of functions to process based on calling function code (@see ChannelSubscription)
+        // Make sure your function can handle sending to a channel id.
         let channel: Discord.TextChannel = bot.channels.cache.get(subscribedChannelId) as Discord.TextChannel
         switch (subscription.featureCode) {
             case 'Ping':
@@ -35,7 +160,7 @@ export default class SubscriptionHandler {
                 break;
         }
 
-        
+
     }
 
     static RunChannelTask(subscription: Subscriptions.ChannelSubscription) {

--- a/src/bot_functions/_state/SubscriptionHandler.ts
+++ b/src/bot_functions/_state/SubscriptionHandler.ts
@@ -1,14 +1,52 @@
+import Bot from '../../Bot';
+import Discord from 'discord.js'
+
 import { Subscriptions } from './../../types/index';
+import BotGeneralCommands from './../general/GeneralCommands'
 
 export default class SubscriptionHandler {
     static RunTask(subscription: Subscriptions.Subscription) {
+        let bot: Bot = globalThis.Bot
 
+        let subscribedChannelId: string
 
         if (subscription instanceof Subscriptions.ChannelSubscription)
-            SubscriptionHandler.RunChannelTask(subscription as Subscriptions.ChannelSubscription)
+            subscribedChannelId = subscription.channelId
+        else if (subscription instanceof Subscriptions.DMSubscription)
+            subscribedChannelId = subscription.dmChannelId
+        else if (subscription instanceof Subscriptions.UserSubscription)
+            subscribedChannelId = subscription.userId
+
+        let channel: Discord.TextChannel = bot.channels.cache.get(subscribedChannelId) as Discord.TextChannel
+        switch (subscription.featureCode) {
+            case 'Ping':
+                BotGeneralCommands.firePingPongMessage(channel)
+                break;
+            case 'DayCounter':
+                //TODO
+                break;
+            case 'QuoteFetch':
+                //TODO
+                break;
+            case 'RedditPost':
+                //TODO
+                break;
+            default:
+                break;
+        }
+
+        
     }
 
     static RunChannelTask(subscription: Subscriptions.ChannelSubscription) {
 
     }
+    static RunUserTask(subscription: Subscriptions.UserSubscription) {
+
+    }
+    static RunDMTask(subscription: Subscriptions.DMSubscription) {
+
+    }
+
+
 }

--- a/src/bot_functions/_state/SubscriptionHandler.ts
+++ b/src/bot_functions/_state/SubscriptionHandler.ts
@@ -280,8 +280,7 @@ export default class BotSubscriptionHandler {
                 BotModuleReddit.fireCopypastaFetch(channel)
                 break;
             case 'SHITPOSTTIME':
-                //! TODO Reroute the message to the function instead of just Context
-                BotModuleReddit.fireRedditSubmissionMessage('r/shitpostingdfsadfasd', 'best', channel)
+                BotModuleReddit.fireRedditSubmissionMessage(channel, 'r/shitpostingdfsadfasd')
                 break;
             default:
                 break;
@@ -312,8 +311,8 @@ export default class BotSubscriptionHandler {
             let lastTime = new Date(sub._lastRun)
 
             // Checks if this ran before the next interval
-            if ((sub.featureCode !== 'NOTHING'
-                && (lastTime?.getMilliseconds() - currentTime) > sub.frequencyMilli)) {
+            if ((sub.featureCode !== 'NOTHING' && sub._enabled
+                && (currentTime - lastTime?.getMilliseconds()) > sub.frequencyMilli)) {
                 if (log) {
                     console.group(`Performing subscription ${sub.name}'s task for ${sub.channelId}${sub.dmChannelId}.`)
                     console.log(`The current time has passed this subscription's last run interval.`)

--- a/src/bot_functions/_state/SubscriptionHandler.ts
+++ b/src/bot_functions/_state/SubscriptionHandler.ts
@@ -189,7 +189,7 @@ export default class BotSubscriptionHandler {
                 return null
             }
             console.log(`Subscription not found. Creating.`)
-            subscription = this.createSubscription(id, name, caller)
+            return this.updateSubscription(id, name, this.createSubscription(id, name, caller)) //! TODO yeah idk fix this
         }
 
         console.log(`Old Data:`)
@@ -296,9 +296,12 @@ export default class BotSubscriptionHandler {
         subscriptions.forEach(sub => {
             let currentTime = Date.now()
 
-            // Checks if this ran before the next interval
-            if ((sub._lastRun.getMilliseconds() - currentTime) < sub.frequencyMilli)
-                this.runTask(sub)
+            if (sub.featureCode = 'NOTHING')
+
+                // Checks if this ran before the next interval
+                if ((sub.featureCode !== 'NOTHING'
+                    && (sub._lastRun?.getMilliseconds() - currentTime) < sub.frequencyMilli))
+                    this.runTask(sub)
         })
 
         console.log('AUTOMATION - Finished running all subscribed tasks for channels!')

--- a/src/bot_functions/_state/SubscriptionHandler.ts
+++ b/src/bot_functions/_state/SubscriptionHandler.ts
@@ -22,6 +22,7 @@ let dataSkeleton: Data.SubscriptionSave =
 {
     _type: 'test',
     _enabled: false,
+    _lastRun: new Date(),
     name: 'butt',
     frequencyMilli: 0,
     featureCode: 'NOTHING',
@@ -289,5 +290,17 @@ export default class BotSubscriptionHandler {
 
     }
 
+    static RunSubscribedTasks() {
+        let subscriptions = BotSubscriptionHandler.getSubscriptionDatastore()
 
+        subscriptions.forEach(sub => {
+            let currentTime = Date.now()
+
+            // Checks if this ran before the next interval
+            if ((sub._lastRun.getMilliseconds() - currentTime) < sub.frequencyMilli)
+                this.runTask(sub)
+        })
+
+        console.log('AUTOMATION - Finished running all subscribed tasks for channels!')
+    }
 }

--- a/src/bot_functions/_state/SubscriptionHandler.ts
+++ b/src/bot_functions/_state/SubscriptionHandler.ts
@@ -18,6 +18,8 @@ import { Data } from './../../types/data_types/Data'
 import { Subscriptions } from './../../types/index';
 import BotGeneralCommands from './../general/GeneralCommands'
 
+import SUBREFS from '../../bot_knowledge/references/subscriptions.json'
+
 let dataSkeleton: Data.SubscriptionSave =
 {
     _type: 'test',
@@ -143,7 +145,7 @@ export default class BotSubscriptionHandler {
             }
             else if (caller?.channel instanceof Discord.PartialGroupDMChannel) {
                 newSub._type = 'PartialGroup'
-                newSub.dmChannelId = caller.channel.id //TODO Special Partials
+                newSub.dmChannelId = caller.channel.id
             }
             else if (caller?.channel instanceof Discord.DMChannel) {
                 newSub._type = 'DM'
@@ -243,6 +245,10 @@ export default class BotSubscriptionHandler {
             console.log('...successfully deleted!')
             return true
         }
+    }
+
+    static getFunctionTypeDescription(featureCode: string): any {
+        return SUBREFS.type_descriptions[featureCode]
     }
 
     static runTask(subscription: Subscriptions.ChannelSubscription | Subscriptions.DMSubscription | Data.SubscriptionSave) {

--- a/src/bot_functions/_state/SubscriptionHandler.ts
+++ b/src/bot_functions/_state/SubscriptionHandler.ts
@@ -245,7 +245,7 @@ export default class BotSubscriptionHandler {
         }
     }
 
-    static runTask(subscription: Subscriptions.ChannelSubscription | Subscriptions.DMSubscription) {
+    static runTask(subscription: Subscriptions.ChannelSubscription | Subscriptions.DMSubscription | Data.SubscriptionSave) {
         let bot: Bot = globalThis.bot
 
         let subscribedChannelId: string

--- a/src/bot_functions/_state/SubscriptionHandler.ts
+++ b/src/bot_functions/_state/SubscriptionHandler.ts
@@ -1,10 +1,14 @@
-import BotTimeKeeper from '../_state/TimeKeeper'
+import { Subscriptions } from './../../types/index';
 
-import BotDiscordActivity from './DiscordActivityStatus'
-import BotModuleSwearJar from "../novelty/swear/SwearJarFunctions"
-import BotModuleBirthday from "../novelty/birthday/BirthdayFunctions"
-import BotData from '../DataHandler'
+export default class SubscriptionHandler {
+    static RunTask(subscription: Subscriptions.Subscription) {
 
-export default class TimelyFunctions {
 
+        if (subscription instanceof Subscriptions.ChannelSubscription)
+            SubscriptionHandler.RunChannelTask(subscription as Subscriptions.ChannelSubscription)
+    }
+
+    static RunChannelTask(subscription: Subscriptions.ChannelSubscription) {
+
+    }
 }

--- a/src/bot_functions/_state/SubscriptionHandler.ts
+++ b/src/bot_functions/_state/SubscriptionHandler.ts
@@ -275,11 +275,15 @@ export default class BotSubscriptionHandler {
             case 'REDDITPOST':
                 //TODO
                 break;
+            case 'SHITPOSTTIME':
+                //TODO
+                break;
             default:
                 break;
         }
 
-
+        subscription._lastRun = Date.now()
+        this.updateSubscription(subscribedChannelId, subscription.name, subscription as Data.SubscriptionSave)
     }
 
     static RunChannelTask(subscription: Subscriptions.ChannelSubscription) {
@@ -304,7 +308,7 @@ export default class BotSubscriptionHandler {
 
             // Checks if this ran before the next interval
             if ((sub.featureCode !== 'NOTHING'
-                && (lastTime?.getMilliseconds() - currentTime) < sub.frequencyMilli)) {
+                && (lastTime?.getMilliseconds() - currentTime) > sub.frequencyMilli)) {
                 if (log) {
                     console.group(`Performing subscription ${sub.name}'s task for ${sub.channelId}${sub.dmChannelId}.`)
                     console.log(`The current time has passed this subscription's last run interval.`)

--- a/src/bot_functions/_state/TimelyFunctions.ts
+++ b/src/bot_functions/_state/TimelyFunctions.ts
@@ -4,6 +4,7 @@ import BotDiscordActivity from './DiscordActivityStatus'
 import BotModuleSwearJar from "../novelty/swear/SwearJarFunctions"
 import BotModuleBirthday from "../novelty/birthday/BirthdayFunctions"
 import BotData from '../DataHandler'
+import BotSubscriptionHandler from './SubscriptionHandler'
 
 export default class TimelyFunctions {
     static get timeSave() {
@@ -36,6 +37,8 @@ export default class TimelyFunctions {
 
     static runTimeSensitive(log?: boolean) {
         this.checkLastRun()
+
+        BotSubscriptionHandler.RunSubscribedTasks()
 
         if (!this.doneForDateMonth) {
 
@@ -84,4 +87,5 @@ export default class TimelyFunctions {
 
         this.timeSave = timeObject
     }
+
 }

--- a/src/bot_functions/fetching/reddit/RedditFunctions.ts
+++ b/src/bot_functions/fetching/reddit/RedditFunctions.ts
@@ -6,7 +6,7 @@ import TRIGGERS from '../../../bot_knowledge/triggers/triggers.json'
 
 export default class BotModuleReddit {
 
-    static async fireRedditSubmissionMessage(trigger?: string, channel?: Discord.TextChannel | Discord.DMChannel) {
+    static async fireRedditSubmissionMessage(channel?: Discord.TextChannel | Discord.DMChannel, query?: string, trigger?: string) {
         let bot: Bot = globalThis.bot
         if (trigger) bot.preliminary(trigger, 'reddit post fetch', true)
 
@@ -17,7 +17,8 @@ export default class BotModuleReddit {
                 channel = channel ? channel : bot.context.channel as Discord.DMChannel
         }
 
-        let query = bot.context.toString().toLowerCase()
+        if (!query)
+            query = bot.context.toString().toLowerCase()
 
         for (const keyword of TRIGGERS.context_prefix)
             if (query.includes(keyword)) {

--- a/src/bot_functions/fetching/reddit/RedditFunctions.ts
+++ b/src/bot_functions/fetching/reddit/RedditFunctions.ts
@@ -6,9 +6,16 @@ import TRIGGERS from '../../../bot_knowledge/triggers/triggers.json'
 
 export default class BotModuleReddit {
 
-    static async fireRedditSubmissionMessage(trigger?: string) {
+    static async fireRedditSubmissionMessage(trigger?: string, channel?: Discord.TextChannel | Discord.DMChannel) {
         let bot: Bot = globalThis.bot
         if (trigger) bot.preliminary(trigger, 'reddit post fetch', true)
+
+        if (!channel) {
+            if (bot.context?.channel instanceof Discord.TextChannel)
+                channel = channel ? channel : bot.context.channel as Discord.TextChannel
+            if (bot.context?.channel instanceof Discord.DMChannel)
+                channel = channel ? channel : bot.context.channel as Discord.DMChannel
+        }
 
         let query = bot.context.toString().toLowerCase()
 
@@ -32,13 +39,14 @@ export default class BotModuleReddit {
         }
 
         this.buildRedditSubmissionMessage(post).forEach(message => {
-            bot.context.channel.send(message)
+            channel.send(message)
         })
         return true
     }
 
-    static async fireCopypastaFetch(trigger?: string) {
+    static async fireCopypastaFetch(channel?: Discord.TextChannel | Discord.DMChannel, trigger?: string) {
         let bot: Bot = globalThis.bot
+        channel = channel ? channel : bot.textChannel
 
         if (trigger) bot.preliminary(trigger, 'reddit copypasta fetch', true)
 
@@ -72,12 +80,12 @@ export default class BotModuleReddit {
                 text = text.match(/(?!&amp#x200B)[\s\S]{1,2000}/g)
 
                 text.forEach((chunk: any) => {
-                    bot.textChannel.send(chunk)
+                    channel.send(chunk)
                 })
             } else delivery.setDescription(pasta.data.selftext)
 
         }
-        bot.textChannel.send(delivery)
+        channel.send(delivery)
     }
 
     static async fireSubmissionImageMessage(redditObject: any) {

--- a/src/bot_functions/general/GeneralCommands.ts
+++ b/src/bot_functions/general/GeneralCommands.ts
@@ -26,6 +26,15 @@ export default class BotGeneralCommands {
         return bot.context.channel.send('redoin, ' + bot.lastMessage.toString())
     }
 
+    static firePingPongMessage(channel: Discord.TextChannel, trigger?: string) {
+        let bot: Bot = globalThis.bot
+        if (trigger) bot.preliminary(trigger, 'Ping pong', true)
+
+        let message = new Discord.Message(bot, { content: '...pong!' }, channel)
+        channel = (bot.channels.cache.get(channel.id) as Discord.TextChannel)
+        return channel.send(message)
+    }
+
     static async killBot(adminOnly = true, trigger: string) {
         let bot: Bot = globalThis.bot
         bot.preliminary(trigger, 'Bot kill', true)

--- a/src/bot_functions/general/HelpTriggers.ts
+++ b/src/bot_functions/general/HelpTriggers.ts
@@ -3,6 +3,7 @@ import TriggerHandlers from '../TriggerHandlers'
 
 import { help_author, help_functions, help_special, help_reference, i } from '../../bot_knowledge/triggers/trigger_info.json'
 import { memes } from '../../bot_knowledge/references/imgflip.json'
+import subscription_reference from '../../bot_knowledge/references/subscriptions.json'
 
 import PHRASES_FRONT from '../../bot_knowledge/phrases/phrases_front.json'
 import PHRASES_SING from '../../bot_knowledge/phrases/phrases_sing.json'
@@ -36,6 +37,8 @@ export default class HelpTriggers {
                             return HelpTriggers.replyForTranslateInfo(message)
                         case 'meme':
                             return HelpTriggers.replyForMemeInfo(message)
+                        case 'subscription':
+                            return HelpTriggers.replyForSubscriptionTypeInfo(message)
                         case 'general':
                             return HelpTriggers.replyForGeneralInfo(message)
                     }
@@ -111,6 +114,20 @@ export default class HelpTriggers {
         })
 
         listedMessage.setDescription(languageList)
+
+        return message.channel.send(listedMessage)
+    }
+
+    static replyForSubscriptionTypeInfo(message = TriggerHandlers.message) {
+        TriggerHandlers.bot.preliminary(message.toString(), 'Help with Subscriptions', true)
+
+        let listedMessage = new Discord.MessageEmbed()
+            .setTitle("Subscription Type List ⚡")
+            .setAuthor(this.helpAuthor)
+            .setColor('GREEN')
+
+        for (const [key, value] of Object.entries(subscription_reference.type_descriptions))
+            listedMessage.addField(key, value)
 
         return message.channel.send(listedMessage)
     }

--- a/src/bot_functions/general/SubscriptionCommands.ts
+++ b/src/bot_functions/general/SubscriptionCommands.ts
@@ -4,6 +4,8 @@ import { Data } from './../../types/data_types/Data';
 import { Subscriptions } from './../../types/data_types/Subscription';
 import BotSubscriptionHandler from '../_state/SubscriptionHandler';
 
+import TRIGGERS from '../../bot_knowledge/triggers/triggers.json'
+
 export default class BotSubscriptionCommands {
 
     static createSubscription(message: Discord.Message, trigger: string, args?: any) {
@@ -85,18 +87,59 @@ export default class BotSubscriptionCommands {
         return true
     }
 
+    static updateSubscription(message: Discord.Message, trigger: string) {
+        // Filter like 'edit/change subscription [time/name/function] to [x]
+        let bot: Bot = globalThis.bot
+        bot.preliminary(trigger, 'Function subscription management - Subscription Edit', true)
+
+        let ctx: string =
+            message.content.substr(message.content.indexOf(trigger) + trigger.length).trim()
+        let subName: string =
+            ctx.substr(ctx.indexOf(`'`) + 1, ctx.lastIndexOf(`'`) - 1).trim() //? Improve
+        let subscription =
+            BotSubscriptionHandler.getSubscription(message.channel.id, name)
+
+        if (!subscription)
+            return message.channel.send(`Subscription named ${subName} not found.`)
+
+        //TODO Priority 1
+        for (const param of TRIGGERS.subscription.update.params.time)
+            if (ctx.toLowerCase().startsWith(param)) {
+                //thing
+                return
+            }
+        for (const param of TRIGGERS.subscription.update.params.name)
+            if (ctx.toLowerCase().startsWith(param)) {
+                //thing
+                return
+            }
+        for (const param of TRIGGERS.subscription.update.params.function)
+            if (ctx.toLowerCase().startsWith(param)) {
+                //thing
+                return
+            }
+        for (const param of TRIGGERS.subscription.update.params.toggle)
+            if (ctx.toLowerCase().startsWith(param)) {
+                //thing
+                return
+            }
+
+        // All else fails
+        return message.channel.send(`Invalid parameter or data. *;help subscriptions* for more info.`)
+    }
+
     static getSubscription(message: Discord.Message, trigger: string) {
         let bot: Bot = globalThis.bot
         bot.preliminary(trigger, 'Function subscription management - Subscription Inquiry', true)
 
-        //TODO
+        //TODO Priority 2
     }
 
     static listSubscriptionsForChannel(message: Discord.Message, trigger: string) {
         let bot: Bot = globalThis.bot
         bot.preliminary(trigger, 'Function subscription management - Listing', true)
 
-        //TODO
+        //TODO Priority 2
     }
 
     static msToTimeMessage(duration: number): string {

--- a/src/bot_functions/general/SubscriptionCommands.ts
+++ b/src/bot_functions/general/SubscriptionCommands.ts
@@ -110,7 +110,7 @@ export default class BotSubscriptionCommands {
 
         for (const param of TRIGGERS.subscription.update.params.time)
             if (command.toLowerCase().startsWith(param)) {
-                subscription.durationMilli = this.convertToMilliseconds(command.substr(command.indexOf('to') + 2).trim())
+                subscription.frequencyMilli = this.convertToMilliseconds(command.substr(command.indexOf('to') + 2).trim())
                 message.channel.send(`Updated the time interval for '${subName}' to *${command.substr(command.indexOf('to') + 2).trim()}*!`)
                 break
             }
@@ -173,6 +173,9 @@ export default class BotSubscriptionCommands {
             return sub.channelId === message.channel.id || sub.dmChannelId === message.channel.id
         })
 
+        if (!subscriptions)
+            return message.channel.send(`This channel has no subscriptions...`)
+
         let response = new Discord.MessageEmbed()
             .setColor('GREEN')
 
@@ -184,6 +187,8 @@ export default class BotSubscriptionCommands {
         subscriptions.forEach(sub => {
             response.addField(sub.name, `${sub.featureCode} every ${this.msToTimeMessage(sub.frequencyMilli)}- Creator: ${bot.users.cache.get(sub.authorId)}`)
         })
+
+        return message.channel.send(response)
     }
 
     static msToTimeMessage(duration: number): string {

--- a/src/bot_functions/general/SubscriptionCommands.ts
+++ b/src/bot_functions/general/SubscriptionCommands.ts
@@ -50,7 +50,7 @@ export default class BotSubscriptionCommands {
 
         let response = new Discord.MessageEmbed()
             .setColor('GREEN')
-            .setDescription('todo') //TODO
+            .setDescription('todo')  //TODO: Subscription's function's description?
 
         if (message.channel instanceof Discord.TextChannel)
             response.setTitle(`Subscription named *${name}* created for channel ${message.channel.name}!`)

--- a/src/bot_functions/general/SubscriptionCommands.ts
+++ b/src/bot_functions/general/SubscriptionCommands.ts
@@ -53,7 +53,7 @@ export default class BotSubscriptionCommands {
 
         let response = new Discord.MessageEmbed()
             .setColor('GREEN')
-            .setDescription(BotSubscriptionHandler.getFunctionTypeDescription(subscription.featureCode))  //TODO: Subscription's function's description?
+            .setDescription(BotSubscriptionHandler.getFunctionTypeDescription(subscription.featureCode))
 
         if (message.channel instanceof Discord.TextChannel)
             response.setTitle(`Subscription named *${name}* created for channel ${message.channel.name}!`)
@@ -174,7 +174,7 @@ export default class BotSubscriptionCommands {
             else return false
         })
 
-        if (!subscriptions)
+        if (subscriptions.length <= 0)
             return message.channel.send(`This channel has no subscriptions...`)
 
         let response = new Discord.MessageEmbed()

--- a/src/bot_functions/general/SubscriptionCommands.ts
+++ b/src/bot_functions/general/SubscriptionCommands.ts
@@ -53,7 +53,7 @@ export default class BotSubscriptionCommands {
 
         let response = new Discord.MessageEmbed()
             .setColor('GREEN')
-            .setDescription('todo')  //TODO: Subscription's function's description?
+            .setDescription(BotSubscriptionHandler.getFunctionTypeDescription(subscription.featureCode))  //TODO: Subscription's function's description?
 
         if (message.channel instanceof Discord.TextChannel)
             response.setTitle(`Subscription named *${name}* created for channel ${message.channel.name}!`)
@@ -170,7 +170,8 @@ export default class BotSubscriptionCommands {
         bot.preliminary(trigger, 'Function subscription management - Listing', true)
 
         let subscriptions: Data.SubscriptionSave[] = BotSubscriptionHandler.getSubscriptionDatastore().filter(sub => {
-            return sub.channelId === message.channel.id || sub.dmChannelId === message.channel.id
+            if (sub.channelId === message.channel.id || sub.dmChannelId === message.channel.id) return true
+            else return false
         })
 
         if (!subscriptions)
@@ -185,7 +186,7 @@ export default class BotSubscriptionCommands {
             response.setTitle(`Subscriptions for this DM`)
 
         subscriptions.forEach(sub => {
-            response.addField(sub.name, `${sub.featureCode} every ${this.msToTimeMessage(sub.frequencyMilli)}- Creator: ${bot.users.cache.get(sub.authorId)}`)
+            response.addField(sub.name, `${sub.featureCode} every ${this.msToTimeMessage(sub.frequencyMilli)} - Creator: ${bot.users.cache.get(sub.authorId)}`)
         })
 
         return message.channel.send(response)

--- a/src/bot_functions/general/SubscriptionCommands.ts
+++ b/src/bot_functions/general/SubscriptionCommands.ts
@@ -1,0 +1,52 @@
+import Discord from 'discord.js'
+import Bot from "../../Bot"
+import { Subscriptions } from './../../types/data_types/Subscription';
+import BotSubscriptionHandler from '../_state/SubscriptionHandler';
+
+export default class BotSubscriptionCommands {
+
+    static createSubscription(message: Discord.Message, trigger: string) {
+        let bot: Bot = globalThis.bot
+        bot.preliminary(trigger, 'Function subscription management - Creation', true)
+
+        let ctx: string =
+            message.content.substr(message.content.indexOf(trigger) + trigger.length).trim()
+
+        let name: string =
+            ctx.substr(ctx.indexOf('name') + 4, ctx.indexOf('for')).trim()
+
+        let funcName: string =
+            ctx.substr(ctx.indexOf('for') + 3).trim()
+
+        let subscription = BotSubscriptionHandler.createSubscription(message.channel.id, name)
+
+        if (message.channel instanceof Discord.TextChannel)
+            subscription.channelId = message.channel.id
+        if (message.channel instanceof Discord.DMChannel)
+            subscription.dmChannelId = message.channel.id
+
+        //TODO
+        subscription.featureCode = (funcName as Subscriptions.SubscriptionFeature)
+    }
+
+    static deleteSubscription(message: Discord.Message, trigger: string) {
+        let bot: Bot = globalThis.bot
+        bot.preliminary(trigger, 'Function subscription management - Deletion', true)
+
+        //TODO
+    }
+
+    static getSubscription(message: Discord.Message, trigger: string) {
+        let bot: Bot = globalThis.bot
+        bot.preliminary(trigger, 'Function subscription management - Subscription Inquiry', true)
+
+        //TODO
+    }
+
+    static listSubscriptionsForId(message: Discord.Message, trigger: string) {
+        let bot: Bot = globalThis.bot
+        bot.preliminary(trigger, 'Function subscription management - Listing', true)
+
+        //TODO
+    }
+}

--- a/src/bot_functions/general/SubscriptionCommands.ts
+++ b/src/bot_functions/general/SubscriptionCommands.ts
@@ -37,6 +37,7 @@ export default class BotSubscriptionCommands {
         try {
             subscription.featureCode = (funcName as Subscriptions.SubscriptionFeature)
             subscription.frequencyMilli = 86400000 // 1 Day
+            subscription.authorId = message.author.id
             subscription._enabled = true
             subscription.args = args
 
@@ -151,7 +152,7 @@ export default class BotSubscriptionCommands {
 
         let response = new Discord.MessageEmbed()
             .setColor('GREEN')
-            .setDescription('todo')  //TODO: Subscription's function's description?
+            .setDescription(BotSubscriptionHandler.getFunctionTypeDescription(subscription.featureCode))
 
         response.setTitle(`*${name}*`)
 
@@ -168,7 +169,21 @@ export default class BotSubscriptionCommands {
         let bot: Bot = globalThis.bot
         bot.preliminary(trigger, 'Function subscription management - Listing', true)
 
-        //TODO Priority 2
+        let subscriptions: Data.SubscriptionSave[] = BotSubscriptionHandler.getSubscriptionDatastore().filter(sub => {
+            return sub.channelId === message.channel.id || sub.dmChannelId === message.channel.id
+        })
+
+        let response = new Discord.MessageEmbed()
+            .setColor('GREEN')
+
+        if (message.channel instanceof Discord.TextChannel)
+            response.setTitle(`Subscriptions for *${message.channel.name}*`)
+        if (message.channel instanceof Discord.DMChannel)
+            response.setTitle(`Subscriptions for this DM`)
+
+        subscriptions.forEach(sub => {
+            response.addField(sub.name, `${sub.featureCode} every ${this.msToTimeMessage(sub.frequencyMilli)}- Creator: ${bot.users.cache.get(sub.authorId)}`)
+        })
     }
 
     static msToTimeMessage(duration: number): string {

--- a/src/bot_functions/language/MorseFunctions.ts
+++ b/src/bot_functions/language/MorseFunctions.ts
@@ -1,0 +1,74 @@
+import Discord from 'discord.js'
+import Bot from './../../Bot'
+
+import { translate } from '../../bot_knowledge/triggers/triggers.json'
+
+import Morse from 'morse'
+
+export default class MorseCoderFunctions {
+    static generateMorseTranslationMessage(trigger: string, to?: string, text?: string) {
+        let bot: Bot = globalThis.bot
+        bot.preliminary(trigger, 'Morse to Text conversion', true)
+
+        let conversion
+
+        if (!text) {
+            text = bot.context.toString()
+            translate.morse.default.some(hotword => {
+                if (text.toLowerCase().includes(hotword)) {
+                    text = text.slice(text.indexOf(hotword) + hotword.length).trim()
+                }
+            })
+        }
+
+        if (to == 'morse-to-text')
+            conversion = this.convertToMorse(text)
+        else if (to == 'text-to-morse')
+            conversion = this.convertToText(text)
+        else
+            conversion = this.autoConvert(text, true)
+
+        conversion = conversion.replace(/\[(.*?)\]/g, '').match(/.{1,2040}/gs)
+
+        let built = new Array<Discord.MessageEmbed>()
+
+        let message = new Discord.MessageEmbed()
+            .setDescription(conversion)
+            .setColor('GOLD')
+            .setFooter('Morse <-> Text')
+
+        built.push(message)
+
+        if (conversion.length > 1) {
+            for (let i = 1; i < conversion.length; i++) {
+                let add = new Discord.MessageEmbed()
+                    .setDescription(conversion)
+                    .setColor('GOLD')
+                    .setFooter('Morse <-> Text')
+
+                built.push(add)
+            }
+        }
+
+        built.forEach(part => {
+            bot.context.channel.send(part)
+        });
+    }
+
+    static convertToMorse(text: string) {
+        var converted = Morse.encode(text)
+        return converted
+    }
+
+    static convertToText(morseCode: string) {
+        var converted = Morse.decode(morseCode)
+        return converted
+    }
+
+    static autoConvert(content: string, spaces?: boolean) {
+        //todo: detect string?
+
+        var converted = Morse.auto(content, spaces)
+        return converted
+    }
+}

--- a/src/bot_functions/language/TranslationFunctions.ts
+++ b/src/bot_functions/language/TranslationFunctions.ts
@@ -6,11 +6,13 @@ import { translate } from '../../bot_knowledge/triggers/triggers.json'
 import WarcraftLanguageFunctions from './WarcraftLangFunctions'
 import YodaLanguageFunctions from './YodaLangFunctions'
 import BinaryCoderFunctions from './BinaryFunctions'
+import MorseCoderFunctions from './MorseFunctions'
 
 export default class BotModuleTranslation {
 
     static processTranslationRequest(context: Discord.Message | Discord.PartialMessage, language?: string, trigger?: string) {
         let lingua: string
+        let args: string
 
         if (translate.hotword_to.some(hotword => {
             if (context.toString().includes(hotword))
@@ -20,6 +22,17 @@ export default class BotModuleTranslation {
                     return lingua = 'yoda'
                 else if (translate.binary.some(h => context.toString().includes(h)))
                     return lingua = 'binary'
+                else if (translate.morse.default.some(h => context.toString().includes(h))) {
+                    translate.morse.to.some(hotword => {
+                        if (context.toString().includes(hotword))
+                            return args = 'to'
+                    })
+                    translate.morse.from.some(hotword => {
+                        if (context.toString().includes(hotword))
+                            return args = 'from'
+                    })
+                    return lingua = 'morse'
+                }
                 else
                     return lingua = '!'
         }))
@@ -29,6 +42,14 @@ export default class BotModuleTranslation {
                 YodaLanguageFunctions.generateYodaTranslationMessage(context.toString())
             else if (lingua == 'binary')
                 BinaryCoderFunctions.generateBinaryTranslationMessage(context.toString())
+            else if (lingua == 'morse') {
+                if (args == 'to')
+                    MorseCoderFunctions.generateMorseTranslationMessage(context.toString(), 'morse-to-text')
+                else if (args == 'from')
+                    MorseCoderFunctions.generateMorseTranslationMessage(context.toString(), 'text-to-morse')
+                else
+                    MorseCoderFunctions.generateMorseTranslationMessage(context.toString())
+            }
             else
                 return this.replyUnknownLanguageMessage()
         else

--- a/src/bot_knowledge/references/subscriptions.json
+++ b/src/bot_knowledge/references/subscriptions.json
@@ -1,0 +1,8 @@
+{
+    "type_descriptions": {
+        "PING": "sdfd",
+        "DAYCOUNTER": "sdfd",
+        "REDDITFETCH": "sdasd",
+        "QUOTEFETCH": "sdfasd"
+    }
+}

--- a/src/bot_knowledge/references/subscriptions.json
+++ b/src/bot_knowledge/references/subscriptions.json
@@ -4,6 +4,7 @@
         "DAYCOUNTER": "Reminds you how many days it has been since a set time.",
         "REDDITFETCH": "Get the top post of a subreddit at the moment.",
         "QUOTEFETCH": "Gets a quote from a specific category.",
-        "SHITPOSTTIME": "Gets a shitpost from r/copypasta"
+        "SHITPOSTTIME": "Gets a shitpost from r/shitposting",
+        "COPYPASTATIME": "Gets that sweet sweet copypasta from r/copypasta"
     }
 }

--- a/src/bot_knowledge/references/subscriptions.json
+++ b/src/bot_knowledge/references/subscriptions.json
@@ -1,8 +1,9 @@
 {
     "type_descriptions": {
-        "PING": "sdfd",
-        "DAYCOUNTER": "sdfd",
-        "REDDITFETCH": "sdasd",
-        "QUOTEFETCH": "sdfasd"
+        "PING": "Returns a pong message. Nothing else much?",
+        "DAYCOUNTER": "Reminds you how many days it has been since a set time.",
+        "REDDITFETCH": "Get the top post of a subreddit at the moment.",
+        "QUOTEFETCH": "Gets a quote from a specific category.",
+        "SHITPOSTTIME": "Gets a shitpost from r/copypasta"
     }
 }

--- a/src/bot_knowledge/triggers/trigger_info.json
+++ b/src/bot_knowledge/triggers/trigger_info.json
@@ -103,6 +103,11 @@
             "meme list",
             "meme store",
             "meme topics"
+        ],
+        "subscription": [
+            "list subscription types",
+            "list subscription functions",
+            "list subscription abilities"
         ]
     },
     "help_reference": {
@@ -367,7 +372,7 @@
         },
         "translate": {
             "_title": "Translating",
-            "_description": "Send text to Megadork to translate to a known language. *megadork translate list* for a list of languages.",
+            "_description": "Send text to Megadork to translate to a known language. *megadork translation list* for a list of languages.",
             "_footer": "💬",
             "_command_list": {
                 "default": {
@@ -511,6 +516,33 @@
                 "random_gif": {
                     "title": "Fetch random GIF from GIPHY",
                     "example": "megadork fetch random gif"
+                }
+            }
+        },
+        "subscriptions": {
+            "_title": "Subscriptions",
+            "_description": "Subscription management for automating functions to your channel! Type ;list subscription types for available functions.",
+            "_footer": "⚡",
+            "_command_list": {
+                "create_subscription": {
+                    "title": "Create subscription",
+                    "example": "megadork create subscription ***name*** for ***function code***"
+                },
+                "get_subscription": {
+                    "title": "Get subscription's info",
+                    "example": "megadork get subscription ***name***"
+                },
+                "get_all_subscriptions": {
+                    "title": "Get a channel's available subscriptions",
+                    "example": "megadork get subscriptions"
+                },
+                "change_subscription": {
+                    "title": "Edit subscription",
+                    "example": "megadork change subscription '***name***' ***attribute*** to ***x*** (Attributes: time, name, toggle, functiontype)"
+                },
+                "delete_subscription": {
+                    "title": "Delete subscription",
+                    "example": "megadork delete subscription ***name***"
                 }
             }
         }

--- a/src/bot_knowledge/triggers/trigger_info.json
+++ b/src/bot_knowledge/triggers/trigger_info.json
@@ -108,6 +108,7 @@
     "help_reference": {
         "translate": [
             "binary (and 'text from binary')",
+            "morse (and 'text from morse')",
             "draenei",
             "dwarven",
             "gnomish",

--- a/src/bot_knowledge/triggers/triggers.json
+++ b/src/bot_knowledge/triggers/triggers.json
@@ -1029,7 +1029,22 @@
             "binary text",
             "hackerspeak",
             "text from binary"
-        ]
+        ],
+        "morse": {
+            "default": [
+                "morse",
+                "morse speak",
+                "beepspeak"
+            ],
+            "to": [
+                "to morse",
+                "to morse speak"
+            ],
+            "from": [
+                "to text from morse",
+                "to text from morse speak"
+            ]
+        }
     },
     "covid": {
         "default": [

--- a/src/bot_knowledge/triggers/triggers.json
+++ b/src/bot_knowledge/triggers/triggers.json
@@ -1244,6 +1244,14 @@
             "list subscriptions",
             "get subscriptions",
             "fetch subscriptions"
-        ]
+        ],
+        "update": {
+            "params": {
+                "name": [],
+                "time": [],
+                "function": [],
+                "toggle": []
+            }
+        }
     }
 }

--- a/src/bot_knowledge/triggers/triggers.json
+++ b/src/bot_knowledge/triggers/triggers.json
@@ -1247,10 +1247,21 @@
         ],
         "update": {
             "params": {
-                "name": [],
-                "time": [],
-                "function": [],
-                "toggle": []
+                "name": [
+                    "name",
+                    "title"
+                ],
+                "time": [
+                    "time",
+                    "frequency",
+                    "interval"
+                ],
+                "function": [
+                    "function"
+                ],
+                "toggle": [
+                    "toggle"
+                ]
             }
         }
     }

--- a/src/bot_knowledge/triggers/triggers.json
+++ b/src/bot_knowledge/triggers/triggers.json
@@ -1222,5 +1222,28 @@
         "default": [
             "ping"
         ]
+    },
+    "subscription": {
+        "create_general": [
+            "create subscription",
+            "make subscription"
+        ],
+        "delete_general": [
+            "delete subscription"
+        ],
+        "update_general": [
+            "update subscription",
+            "change subscription"
+        ],
+        "get_general": [
+            "get subscription",
+            "find subscription",
+            "fetch subscription"
+        ],
+        "list_general": [
+            "list subscriptions",
+            "get subscriptions",
+            "fetch subscriptions"
+        ]
     }
 }

--- a/src/bot_knowledge/triggers/triggers.json
+++ b/src/bot_knowledge/triggers/triggers.json
@@ -1202,5 +1202,10 @@
             "get random gif",
             "give me a random gif"
         ]
+    },
+    "ping_pong": {
+        "default": [
+            "ping"
+        ]
     }
 }

--- a/src/types/data_types/Data.ts
+++ b/src/types/data_types/Data.ts
@@ -17,6 +17,7 @@ export module Data {
         _type: string,
         featureCode: Subscriptions.SubscriptionFeature,
         frequencyMilli: Number,
+        name: string,
         durationMilli?: Number,
         endDate?: Date,
         channelId?: string

--- a/src/types/data_types/Data.ts
+++ b/src/types/data_types/Data.ts
@@ -1,3 +1,5 @@
+import { Subscriptions } from './Subscription';
+
 export module Data {
     export interface UserSave extends Object {
         _id: string
@@ -9,5 +11,18 @@ export module Data {
         last_initiliazed: string
         last_ran_functions: { [key: string]: string }
         [x: string]: any
+    }
+
+    export interface SubscriptionSave extends Object {
+        _type: string,
+        featureCode: Subscriptions.SubscriptionFeature,
+        frequencyMilli: Number,
+        durationMilli?: Number,
+        endDate?: Date,
+        channelId?: string
+        authorId?: string,
+        userId?: string,
+        dmChannelId?: string,
+        [args: string]: any
     }
 }

--- a/src/types/data_types/Data.ts
+++ b/src/types/data_types/Data.ts
@@ -20,7 +20,6 @@ export module Data {
         featureCode: Subscriptions.SubscriptionFeature,
         frequencyMilli: number,
         name: string,
-        durationMilli?: Number,
         endDate?: Date,
         channelId?: string
         authorId?: string,

--- a/src/types/data_types/Data.ts
+++ b/src/types/data_types/Data.ts
@@ -15,6 +15,7 @@ export module Data {
 
     export interface SubscriptionSave extends Object {
         _type: Subscriptions.ChannelType,
+        _enabled: boolean
         featureCode: Subscriptions.SubscriptionFeature,
         frequencyMilli: Number,
         name: string,

--- a/src/types/data_types/Data.ts
+++ b/src/types/data_types/Data.ts
@@ -16,6 +16,7 @@ export module Data {
     export interface SubscriptionSave extends Object {
         _type: Subscriptions.ChannelType,
         _enabled: boolean
+        _lastRun: Date
         featureCode: Subscriptions.SubscriptionFeature,
         frequencyMilli: number,
         name: string,

--- a/src/types/data_types/Data.ts
+++ b/src/types/data_types/Data.ts
@@ -17,7 +17,7 @@ export module Data {
         _type: Subscriptions.ChannelType,
         _enabled: boolean
         featureCode: Subscriptions.SubscriptionFeature,
-        frequencyMilli: Number,
+        frequencyMilli: number,
         name: string,
         durationMilli?: Number,
         endDate?: Date,

--- a/src/types/data_types/Data.ts
+++ b/src/types/data_types/Data.ts
@@ -14,7 +14,7 @@ export module Data {
     }
 
     export interface SubscriptionSave extends Object {
-        _type: string,
+        _type: Subscriptions.ChannelType,
         featureCode: Subscriptions.SubscriptionFeature,
         frequencyMilli: Number,
         name: string,

--- a/src/types/data_types/Subscription.ts
+++ b/src/types/data_types/Subscription.ts
@@ -51,6 +51,6 @@ export module Subscriptions {
         }
     }
 
-    export type SubscriptionFeature = 'Ping' | 'DayCounter' | 'QuoteFetch' | 'RedditPost'
+    export type SubscriptionFeature = 'Nothing' | 'Ping' | 'DayCounter' | 'QuoteFetch' | 'RedditPost'
 
 }

--- a/src/types/data_types/Subscription.ts
+++ b/src/types/data_types/Subscription.ts
@@ -6,7 +6,6 @@ export module Subscriptions {
         _enabled: boolean,
         featureCode: SubscriptionFeature,
         frequencyMilli: Number,
-        durationMilli?: Number,
         endDate?: Date,
         [args: string]: any
     }
@@ -66,7 +65,7 @@ export module Subscriptions {
     }
 
 
-    export type SubscriptionFeature = 'NOTHING' | 'PING' | 'DAYCOUNTER' | 'QUOTEFETCH' | 'REDDITPOST'
+    export type SubscriptionFeature = 'NOTHING' | 'PING' | 'DAYCOUNTER' | 'QUOTEFETCH' | 'REDDITPOST' | 'SHITPOSTTIME'
 
     export type ChannelType = 'test' | 'DM' | 'PartialGroup' | 'GuildChannel'
 

--- a/src/types/data_types/Subscription.ts
+++ b/src/types/data_types/Subscription.ts
@@ -1,3 +1,5 @@
+import Discord from 'discord.js'
+
 export module Subscriptions {
     export interface Subscription extends Object {
         featureCode: SubscriptionFeature,
@@ -6,22 +8,49 @@ export module Subscriptions {
         endDate?: Date,
         [args: string]: any
     }
-    export interface ChannelSubscription extends Subscription {
-        channelId: string,
-        authorId: string
-    }
-
-    export interface UserSubscription extends Subscription {
-        userId: string
-    }
-
-    export interface DMSubscription extends Subscription {
+    export class ChannelSubscription implements Subscription {
+        frequencyMilli: Number
         channelId: string
+        authorId: string
+        featureCode: SubscriptionFeature
+        [arg: string]: any
+
+        constructor(callingUser: Discord.GuildMember, featureCode: SubscriptionFeature, frequencyMilli: Number, args?: any) {
+            this.authorId = callingUser.id
+            this.channelId = callingUser.lastMessageChannelID
+            this.featureCode = featureCode
+            this.frequencyMilli = frequencyMilli
+        }
     }
 
-    export enum SubscriptionFeature {
-        Ping,
-        DayCounter,
-        RedditPost
+    export class UserSubscription implements Subscription {
+        userId: string
+        featureCode: SubscriptionFeature
+        frequencyMilli: Number
+        [arg: string]: any
+
+        constructor(callingUser: Discord.User, featureCode: SubscriptionFeature, args?: any) {
+            this.userId = callingUser.id
+            this.featureCode = featureCode
+            this.frequencyMilli
+        }
     }
+
+    export class DMSubscription implements Subscription {
+        [args: string]: any
+        dmChannelId: string
+        featureCode: SubscriptionFeature
+        frequencyMilli: Number
+        durationMilli?: Number
+        endDate?: Date
+
+        constructor(callingDM: Discord.DMChannel, featureCode: SubscriptionFeature, args?: any) {
+            this.dmChannelId = callingDM.id
+            this.featureCode = featureCode
+            this.frequencyMilli = this.frequencyMilli
+        }
+    }
+
+    export type SubscriptionFeature = 'Ping' | 'DayCounter' | 'QuoteFetch' | 'RedditPost'
+
 }

--- a/src/types/data_types/Subscription.ts
+++ b/src/types/data_types/Subscription.ts
@@ -65,7 +65,7 @@ export module Subscriptions {
         }
     }
 
-    export type SubscriptionFeature = 'Nothing' | 'Ping' | 'DayCounter' | 'QuoteFetch' | 'RedditPost'
+    export type SubscriptionFeature = 'NOTHING' | 'PING' | 'DAYCOUNTER' | 'QUOTEFETCH' | 'REDDITPOST'
 
     export type ChannelType = 'test' | 'DM' | 'PartialGroup' | 'GuildChannel'
 

--- a/src/types/data_types/Subscription.ts
+++ b/src/types/data_types/Subscription.ts
@@ -2,6 +2,7 @@ import Discord from 'discord.js'
 
 export module Subscriptions {
     export interface Subscription extends Object {
+        name: string,
         featureCode: SubscriptionFeature,
         frequencyMilli: Number,
         durationMilli?: Number,
@@ -9,10 +10,11 @@ export module Subscriptions {
         [args: string]: any
     }
     export class ChannelSubscription implements Subscription {
-        frequencyMilli: Number
+        name: string
         channelId: string
         authorId: string
         featureCode: SubscriptionFeature
+        frequencyMilli: Number
         [arg: string]: any
 
         constructor(callingUser: Discord.GuildMember, featureCode: SubscriptionFeature, frequencyMilli: Number, args?: any) {
@@ -24,6 +26,7 @@ export module Subscriptions {
     }
 
     export class UserSubscription implements Subscription {
+        name: string
         userId: string
         featureCode: SubscriptionFeature
         frequencyMilli: Number
@@ -37,12 +40,11 @@ export module Subscriptions {
     }
 
     export class DMSubscription implements Subscription {
-        [args: string]: any
+        name: string
         dmChannelId: string
         featureCode: SubscriptionFeature
         frequencyMilli: Number
-        durationMilli?: Number
-        endDate?: Date
+        [args: string]: any
 
         constructor(callingDM: Discord.DMChannel, featureCode: SubscriptionFeature, args?: any) {
             this.dmChannelId = callingDM.id

--- a/src/types/data_types/Subscription.ts
+++ b/src/types/data_types/Subscription.ts
@@ -65,7 +65,7 @@ export module Subscriptions {
     }
 
 
-    export type SubscriptionFeature = 'NOTHING' | 'PING' | 'DAYCOUNTER' | 'QUOTEFETCH' | 'REDDITPOST' | 'SHITPOSTTIME'
+    export type SubscriptionFeature = 'NOTHING' | 'PING' | 'DAYCOUNTER' | 'QUOTEFETCH' | 'REDDITPOST' | 'SHITPOSTTIME' | 'COPYPASTATIME'
 
     export type ChannelType = 'test' | 'DM' | 'PartialGroup' | 'GuildChannel'
 

--- a/src/types/data_types/Subscription.ts
+++ b/src/types/data_types/Subscription.ts
@@ -55,4 +55,6 @@ export module Subscriptions {
 
     export type SubscriptionFeature = 'Nothing' | 'Ping' | 'DayCounter' | 'QuoteFetch' | 'RedditPost'
 
+    export type ChannelType = 'test' | 'DM' | 'PartialGroup' | 'GuildChannel'
+
 }

--- a/src/types/data_types/Subscription.ts
+++ b/src/types/data_types/Subscription.ts
@@ -13,6 +13,7 @@ export module Subscriptions {
     export class ChannelSubscription implements Subscription {
         name: string
         _enabled: boolean
+
         channelId: string
         authorId: string
         featureCode: SubscriptionFeature
@@ -24,6 +25,23 @@ export module Subscriptions {
             this.channelId = callingUser.lastMessageChannelID
             this.featureCode = featureCode
             this.frequencyMilli = frequencyMilli
+
+            this._enabled = true
+        }
+    }
+    export class DMSubscription implements Subscription {
+        name: string
+        _enabled: boolean
+
+        dmChannelId: string
+        featureCode: SubscriptionFeature
+        frequencyMilli: Number
+        [args: string]: any
+
+        constructor(callingDM: Discord.DMChannel, featureCode: SubscriptionFeature, args?: any) {
+            this.dmChannelId = callingDM.id
+            this.featureCode = featureCode
+            this.frequencyMilli = this.frequencyMilli
 
             this._enabled = true
         }
@@ -47,23 +65,6 @@ export module Subscriptions {
         }
     }
 
-    export class DMSubscription implements Subscription {
-        name: string
-        _enabled: boolean
-
-        dmChannelId: string
-        featureCode: SubscriptionFeature
-        frequencyMilli: Number
-        [args: string]: any
-
-        constructor(callingDM: Discord.DMChannel, featureCode: SubscriptionFeature, args?: any) {
-            this.dmChannelId = callingDM.id
-            this.featureCode = featureCode
-            this.frequencyMilli = this.frequencyMilli
-
-            this._enabled = true
-        }
-    }
 
     export type SubscriptionFeature = 'NOTHING' | 'PING' | 'DAYCOUNTER' | 'QUOTEFETCH' | 'REDDITPOST'
 

--- a/src/types/data_types/Subscription.ts
+++ b/src/types/data_types/Subscription.ts
@@ -16,10 +16,10 @@ export module Subscriptions {
         channelId: string
         authorId: string
         featureCode: SubscriptionFeature
-        frequencyMilli: Number
+        frequencyMilli: number
         [arg: string]: any
 
-        constructor(callingUser: Discord.GuildMember, featureCode: SubscriptionFeature, frequencyMilli: Number, args?: any) {
+        constructor(callingUser: Discord.GuildMember, featureCode: SubscriptionFeature, frequencyMilli: number, args?: any) {
             this.authorId = callingUser.id
             this.channelId = callingUser.lastMessageChannelID
             this.featureCode = featureCode

--- a/src/types/data_types/Subscription.ts
+++ b/src/types/data_types/Subscription.ts
@@ -3,6 +3,7 @@ import Discord from 'discord.js'
 export module Subscriptions {
     export interface Subscription extends Object {
         name: string,
+        _enabled: boolean,
         featureCode: SubscriptionFeature,
         frequencyMilli: Number,
         durationMilli?: Number,
@@ -11,6 +12,7 @@ export module Subscriptions {
     }
     export class ChannelSubscription implements Subscription {
         name: string
+        _enabled: boolean
         channelId: string
         authorId: string
         featureCode: SubscriptionFeature
@@ -22,11 +24,15 @@ export module Subscriptions {
             this.channelId = callingUser.lastMessageChannelID
             this.featureCode = featureCode
             this.frequencyMilli = frequencyMilli
+
+            this._enabled = true
         }
     }
 
     export class UserSubscription implements Subscription {
         name: string
+        _enabled: boolean
+
         userId: string
         featureCode: SubscriptionFeature
         frequencyMilli: Number
@@ -36,11 +42,15 @@ export module Subscriptions {
             this.userId = callingUser.id
             this.featureCode = featureCode
             this.frequencyMilli
+
+            this._enabled = true
         }
     }
 
     export class DMSubscription implements Subscription {
         name: string
+        _enabled: boolean
+
         dmChannelId: string
         featureCode: SubscriptionFeature
         frequencyMilli: Number
@@ -50,6 +60,8 @@ export module Subscriptions {
             this.dmChannelId = callingDM.id
             this.featureCode = featureCode
             this.frequencyMilli = this.frequencyMilli
+
+            this._enabled = true
         }
     }
 

--- a/src/types/data_types/Subscription.ts
+++ b/src/types/data_types/Subscription.ts
@@ -1,15 +1,27 @@
-import Discord from 'discord.js'
-
 export module Subscriptions {
-    export interface ChannelSubscription extends Object {
-        _id: string
-        featureCode: SubscriptionFeature
+    export interface Subscription extends Object {
+        featureCode: SubscriptionFeature,
+        frequencyMilli: Number,
+        durationMilli?: Number,
+        endDate?: Date,
         [args: string]: any
+    }
+    export interface ChannelSubscription extends Subscription {
+        channelId: string,
+        authorId: string
+    }
+
+    export interface UserSubscription extends Subscription {
+        userId: string
+    }
+
+    export interface DMSubscription extends Subscription {
+        channelId: string
     }
 
     export enum SubscriptionFeature {
         Ping,
-        RedditPost,
-        DayCounter
+        DayCounter,
+        RedditPost
     }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,5 +4,6 @@
 export * from './data_types/Data'
 export * from './data_types/Audio'
 export * from './data_types/Stream'
+export * from './data_types/Subscription'
 
 export * from './data_types/Bean'


### PR DESCRIPTION
Adds the required logic for handling user-created subscriptions which automatically runs a bot's function in a user-specified time interval (in ms)
Includes handling the saving of subscriptions created by users, and loading them on boot and 'update time'
Added user-to-bot commands to trigger the above
Added a new Ping function to test this feature, and to just test the bot's availability
Added new 'S**tpost' function